### PR TITLE
Bugfixes for the new user customization feature

### DIFF
--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -54,7 +54,7 @@
 #endif
 
 // Per-user model-specific overrides
-#ifdef USER_MODEL_H
+#ifdef USER_MODEL_CFG
 #include incfile(USER_MODEL_CFG)
 #endif
 


### PR DESCRIPTION
I tried out this update from ToyKeeper/anduril#57 and found it worked well, apart from a few bugs that came up when building custom hex files.

The make script should now be able to successfully build files with custom settings for any number of users. Users can be specified either in `users.cfg` or by passing `USER` as an argument multiple times (e.g. `./make --user user1 --user user2`).